### PR TITLE
WriteFile takes uint as length, not size_t

### DIFF
--- a/terminalemulator.d
+++ b/terminalemulator.d
@@ -2764,7 +2764,7 @@ mixin template PtySupport(alias resizeHelper) {
 		} else version(Windows) {
 			import std.conv;
 			uint written;
-			if(WriteFile(stdin, data.ptr, data.length, &written, null) == 0)
+			if(WriteFile(stdin, data.ptr, cast(uint)data.length, &written, null) == 0)
 				throw new Exception("WriteFile " ~ to!string(GetLastError()));
 		} else version(Posix) {
 			import core.sys.posix.unistd;


### PR DESCRIPTION
fixes compilation for windows x64